### PR TITLE
Fix test_source_notification

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,4 +37,3 @@ requests_toolbelt>=0.9.1
 sendgrid>=6.4.6
 twilio>=6.45.3
 jsonschema-to-openapi>=0.2.1
-responses>=0.12.0

--- a/skyportal/tests/frontend/test_sources.py
+++ b/skyportal/tests/frontend/test_sources.py
@@ -7,7 +7,6 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.keys import Keys
 from selenium.common.exceptions import TimeoutException
 from PIL import Image, ImageChops
-import responses
 
 from baselayer.app.config import load_config
 from skyportal.tests import api
@@ -460,17 +459,8 @@ def test_dropdown_facility_change(driver, user, public_source):
     driver.wait_for_xpath("//code/div/pre[text()[contains(., 'dist')]]", timeout=45)
 
 
-@pytest.mark.flaky(reruns=2)
-@responses.activate
+# @pytest.mark.flaky(reruns=2)
 def test_source_notification(driver, user, public_group, public_source):
-    # Just test the front-end form and mock out the SkyPortal API call
-    responses.add(
-        responses.GET,
-        "http://localhost:5000/api/source_notifications",
-        json={"status": "success"},
-        status=200,
-    )
-
     driver.get(f"/become_user/{user.id}")
     driver.get(f"/source/{public_source.id}")
     driver.wait_for_xpath(f'//div[text()="{public_source.id}"]')
@@ -484,7 +474,7 @@ def test_source_notification(driver, user, public_group, public_source):
     header = driver.wait_for_xpath("//header")
     ActionChains(driver).move_to_element(header).click().perform()
     driver.click_xpath("//button[@data-testid='sendNotificationButton']")
-    driver.wait_for_xpath("//*[text()='Notification queued up sucessfully']")
+    driver.wait_for_xpath("//*[text()[contains(., 'Invalid email service')]]")
 
 
 def test_unsave_from_group(

--- a/skyportal/tests/frontend/test_sources.py
+++ b/skyportal/tests/frontend/test_sources.py
@@ -459,7 +459,7 @@ def test_dropdown_facility_change(driver, user, public_source):
     driver.wait_for_xpath("//code/div/pre[text()[contains(., 'dist')]]", timeout=45)
 
 
-# @pytest.mark.flaky(reruns=2)
+@pytest.mark.flaky(reruns=2)
 def test_source_notification(driver, user, public_group, public_source):
     driver.get(f"/become_user/{user.id}")
     driver.get(f"/source/{public_source.id}")


### PR DESCRIPTION
It turns out the entire time I thought I was successfully mocking out the call to SP with the `responses` package here, but the call was actually only succeeding because no emails were being sent since no test users have opted in to emails. I think the mocking doesn't work because the pytest is a different process from the firefox instance. Removed the `responses` as a dependency accordingly since it was not used anywhere else.